### PR TITLE
Apply limit and offset to GET requests

### DIFF
--- a/src/PrintNode/Request.php
+++ b/src/PrintNode/Request.php
@@ -112,7 +112,7 @@ class Request
      */
     private function makeEndPointUrls()
     {
-        $endPointUrls;
+        $endPointUrls = array();
         foreach ($this->methodNameEntityMap as $classes) {
             $endPointUrls[$classes] = $this->apiurl.$this->endPointUrls[$classes];
         }
@@ -231,6 +231,8 @@ class Request
     {
         $curlHandle = $this->curlInit();
         curl_setopt($curlHandle, CURLOPT_HTTPHEADER, $this->childauth);
+
+        $endPointUrl = $this->applyOffsetLimit($endPointUrl);
 
         return $this->curlExec(
             $curlHandle,


### PR DESCRIPTION
There is a method for applying the limit and offset to requests. This method was never called. Therefor there was never a limit or offset sent to the API and the API always responded based on the defaults. 

Example: Getting the printer list always responded with max 100 printers.

This PR calls the `applyOffsetLimit` method when doing GET requests, so limit and offset get applied correctly. 

Also made a small fix to declare `$endPointUrls` the right way, since how it was done is not supported.

Tested getting a printer list and applying small limits, combined with an offset which created the right response.