### PR TITLE
Add additionalHeaders to the header of the request

### DIFF
--- a/src/PrintNode/Request.php
+++ b/src/PrintNode/Request.php
@@ -240,7 +240,7 @@ class Request
             $headers[] = 'X-Dont-Log: 1';
         }
         
-        return \array_merge($headers, $this->getCredentialHeader());
+        return \array_merge($headers, $this->getCredentialHeader(), $this->additionalHeaders);
         
     }
     


### PR DESCRIPTION
additionalHeaders can be set in the client, but they are not being used for the reponse. Looks like they are missing from the getHeaders() function.

This simple fix, allows users to set headers such as the Idempotency header as per the API manual:

```
$client = new \PrintNode\Client($credentials);
$client->additionalHeaders = array('X-Idempotency-Key: abcde12345');
```