### PR TITLE
PHP 8.1 compatibility / deprecation warnings

### DIFF
--- a/src/PrintNode/Entity.php
+++ b/src/PrintNode/Entity.php
@@ -102,7 +102,7 @@ abstract class Entity implements \JsonSerializable
      * 
      * @return string
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         
         $json = array();


### PR DESCRIPTION
PHP Deprecated: Return type of PrintNode\Entity::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in .../vendor/printnode/printnode-php/src/PrintNode/Entity.php on line 105

Explanation: https://stackoverflow.com/a/71133750
PrintNode's class Entity implements \JsonSerializable: https://www.php.net/manual/en/class.jsonserializable.php