### PR TITLE
Composer Install should be lower case

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ https://github.com/PrintNode/PrintNode-PHP/archive/master.zip
 ### Install via composer
 
 ```bash
-composer require PrintNode/printnode-php:dev-master
+composer require printnode/printnode-php:dev-master
 ```
 
 ## Step 4: See examples how to use this library


### PR DESCRIPTION
When running: composer require PrintNode/printnode-php:dev-master

In RootPackageLoader.php line 160:
                                                                                                                                       
require.PrintNode/printnode-php is invalid, it should not contain uppercase characters. Please use printnode/printnode-php instead.

changed composer require PrintNode/printnode-php:dev-master ->
composer require printnode/printnode-php:dev-master